### PR TITLE
fix: 修 4 个 smoke test 剩余 regression

### DIFF
--- a/far/_para.py
+++ b/far/_para.py
@@ -408,8 +408,8 @@ class dict_:
                 com2 = '较弱，出现亏损情况'
 
         elif self.data_type == 'no_year1':
-            com1 = '{:,.f}'.format(self.db_data('营业收入','month'))
-            com2 = '{:,.f}'.format(self.db_data('净利润','month'))
+            com1 = '{:,.2f}'.format(self.db_data('营业收入','month'))
+            com2 = '{:,.2f}'.format(self.db_data('净利润','month'))
 
         elif self.data_type == 'all_years':
             # com1

--- a/far/main.py
+++ b/far/main.py
@@ -135,7 +135,9 @@ def para_analysis(doc,conf):
     bold(doc, conf.header.h2s6, 3)
     p6 = doc.add_paragraph(para().s2d6.format(**conf.para.s2d6))
     bold(doc, conf.header.h2s7,3)
-    big_change_sheet(conf, doc)
+    # no_year1 形态没有 year1 列，跳过 big_change_sheet
+    if conf.data_type != 'no_year1':
+        big_change_sheet(conf, doc)
     bold(doc, conf.header.h3,3)
     if conf.data_type == 'no_year1':
         items_detail(conf, doc, 'month')
@@ -270,18 +272,26 @@ def big_change_items(conf_obj):
     list2 = []
     big_change_items = []
     if conf_obj.data_type == 'all_years':
+        # all_years 无 month 列，用 year2 - year1
         for dict in Item:
-            if dict['year1'] == 0 and dict['month'] != 0:
+            if dict.get('year1', 0) == 0 and dict.get('year2', 0) != 0:
                 list1.append(dict)
-            elif dict['year1'] == 0 and dict['month'] == 0:
+            elif dict.get('year1', 0) == 0 and dict.get('year2', 0) == 0:
                 pass
             else:
-                if (dict['month'] - dict['year1']) / dict['year1'] < 0.3 \
-                        and (dict['month'] - dict['year1']) / dict['year1'] > -0.3:
+                y1 = dict.get('year1', 0)
+                y2 = dict.get('year2', 0)
+                if y1 == 0:
+                    pass
+                elif (y2 - y1) / y1 < 0.3 and (y2 - y1) / y1 > -0.3:
                     pass
                 else:
                     list2.append(dict)
-        list_sorted_dict = sorted(list2, key=lambda x: x['month'] - x['year1'], reverse=True)
+        list_sorted_dict = sorted(
+            list2,
+            key=lambda x: x.get('year2', 0) - x.get('year1', 0),
+            reverse=True
+        )
         # 组成当期纯变化和超过30%变化的列表
         for dict in list_sorted_dict:
             list1.append(dict)
@@ -290,18 +300,28 @@ def big_change_items(conf_obj):
             big_change_items.append(dict['items'])
         return big_change_items
     else:
+        # normal / no_year3 / no_year2：当期 = month，比照期 = year1
+        # 用 .get(key, 0) 防御 no_year1 形态下列缺失（虽然函数注释说不用，
+        # 但 para_analysis 138 行仍会调到，做防御性兜底）
         for dict in Item:
-            if dict['year1'] == 0 and dict['year2'] != 0:
+            if dict.get('year1', 0) == 0 and dict.get('month', 0) != 0:
                 list1.append(dict)
-            elif dict['year1'] == 0 and dict['year2'] == 0:
+            elif dict.get('year1', 0) == 0 and dict.get('month', 0) == 0:
                 pass
             else:
-                if (dict['year1']-dict['year2'])/dict['year2'] < 0.3 \
-                        and (dict['year1']-dict['year2'])/dict['year2'] > -0.3:
+                y1 = dict.get('year1', 0)
+                m = dict.get('month', 0)
+                if y1 == 0:
+                    pass
+                elif (m - y1) / y1 < 0.3 and (m - y1) / y1 > -0.3:
                     pass
                 else:
                     list2.append(dict)
-        list_sorted_dict = sorted(list2, key=lambda x: x['year1']-x['year2'], reverse=True)
+        list_sorted_dict = sorted(
+            list2,
+            key=lambda x: x.get('month', 0) - x.get('year1', 0),
+            reverse=True
+        )
         #组成当期纯变化和超过30%变化的列表
         for dict in list_sorted_dict:
             list1.append(dict)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -80,7 +80,7 @@ def _build_all_years_xlsx(name: str) -> str:
 
 
 def _cleanup(name: str):
-    """清掉 mock 产物：input xlsx, db json, output docx"""
+    """清掉 mock 产物：input xlsx（仅 mock 文件，不动模板）, db json, output docx"""
     for path in [INPUT_PATH, OUTPUT_PATH, DB_PATH]:
         for filename in [f'{name}.xlsx', f'{name}.json', f'{name}.docx']:
             full = os.path.join(path, filename)
@@ -145,40 +145,43 @@ class SmokeTest(unittest.TestCase):
     验证 5 套数据形态都能跑通。
 
     设计原则：
-    - `normal` 必须通过——它代表最常见场景，P0 修复（data_type 命名、financial_sheet、
-      big_change_sheet 公式）必须保证这条路径不出错。
-    - 其它 4 套若失败，单独报告（_print_regression），不 fail CI。
-      它们可能是 smoke test 自身问题（mock 数据分布），
-      也可能是本次未列入 P0 的新发现 bug——后者需要单独 issue/PR 修复。
-      （PR #2 修了其中 4 个：format string x2 / s2d4 缺 m 键 / exsit_data_list 越界；
-       仍剩 1 个新发现 bug：big_change_items + no_year1 {:,.f} 缺精度，未修。）
+    - 5 套数据形态（normal / no_year3 / no_year2 / no_year1 / all_years）必须全部通过。
+    - PR #2 修了 4 个 P0 bug（data_type 命名、financial_sheet、big_change_sheet 括号、webapp 加固）。
+    - PR #3 修了 4 个 smoke test regression（format string x2 / s2d4 缺 m 键 / exsit_data_list 越界）。
+    - 本 PR (#4) 修了 4 个剩余 bug（big_change_items 列缺失 x2 / {:,.f} 缺精度 / all_years 错用 month 列），
+      让 5 套数据形态都达到"能跑通"基线。
+    - two_years：项目未演示，跳过。
     """
 
     def test_normal(self):
-        """P0 修复的核心验证：normal 形态必须能跑通"""
+        """normal 形态必须能跑通"""
         r = _run_one('normal')
         print(f'\n  ✅ normal:    docx={r.get("docx_size", "?")}B, db_rows={r.get("db_rows", "?")}')
         self.assertTrue(r['ok'], f'normal 失败: {r.get("err")}')
 
-    def test_no_year3_regression(self):
-        """no_year3 形态：报告问题，不 fail（已修）"""
+    def test_no_year3(self):
+        """no_year3 形态必须能跑通（成立不足 3 年）"""
         r = _run_one('no_year3')
-        _print_regression(r, 'no_year3')
+        print(f'\n  ✅ no_year3:  docx={r.get("docx_size", "?")}B, db_rows={r.get("db_rows", "?")}')
+        self.assertTrue(r['ok'], f'no_year3 失败: {r.get("err")}')
 
-    def test_no_year2_regression(self):
-        """no_year2 形态：报告问题，不 fail（big_change_items 仍 fail）"""
+    def test_no_year2(self):
+        """no_year2 形态必须能跑通（成立不足 2 年）"""
         r = _run_one('no_year2')
-        _print_regression(r, 'no_year2')
+        print(f'\n  ✅ no_year2:  docx={r.get("docx_size", "?")}B, db_rows={r.get("db_rows", "?")}')
+        self.assertTrue(r['ok'], f'no_year2 失败: {r.get("err")}')
 
-    def test_no_year1_regression(self):
-        """no_year1 形态：报告问题，不 fail（{:,.f} 缺精度 仍 fail）"""
+    def test_no_year1(self):
+        """no_year1 形态必须能跑通（成立不足 1 年）"""
         r = _run_one('no_year1')
-        _print_regression(r, 'no_year1')
+        print(f'\n  ✅ no_year1:  docx={r.get("docx_size", "?")}B, db_rows={r.get("db_rows", "?")}')
+        self.assertTrue(r['ok'], f'no_year1 失败: {r.get("err")}')
 
-    def test_all_years_regression(self):
-        """all_years 形态：报告问题，不 fail（已修）"""
+    def test_all_years(self):
+        """all_years 形态必须能跑通（期末数据场景，无 month 列）"""
         r = _run_one('all_years')
-        _print_regression(r, 'all_years')
+        print(f'\n  ✅ all_years: docx={r.get("docx_size", "?")}B, db_rows={r.get("db_rows", "?")}')
+        self.assertTrue(r['ok'], f'all_years 失败: {r.get("err")}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 背景

PR #2 (4 P0) + PR #3 (4 smoke test regression) 合并后，5 套数据形态还有 4 个 fail：

- no_year2: `KeyError: 'year2'`（big_change_items 越界）
- no_year1: `ValueError: Format specifier missing precision`（{:,.f} 缺精度）
- no_year1: `KeyError: 'year1'`（big_change_sheet line 357 无条件访问 year1）
- all_years: `KeyError: 'month'`（big_change_items 错用 month 列）

本 PR 全部修掉，5 套数据形态 smoke test 必过。

## 改动 (3 files, +57/-34)

### far/main.py

1. **big_change_items (line 272-308)**: all_years 分支用 year2 - year1（原本错用 month），else 分支用 month - year1（原本错用 year2）。同时所有 `dict['xxx']` 改为 `dict.get('xxx', 0)` 防御列缺失。
2. **para_analysis (line 138)**: no_year1 形态下跳过 big_change_sheet（line 357 无条件 `data(conf, item, 'year1')` 越界）。

### far/_para.py

3. **line 411-412**: `{:,.f}` -> `{:,.2f}`（no_year1 缺精度）。

### tests/test_smoke.py

4. **5 套数据形态全部改为 assertTrue 必过**（PR #3 时 4 套设为"报告不 fail"，本 PR 修完后提升为必过）。

## Smoke test 结果

```
Ran 5 tests in 36.508s
OK
normal:    docx=158313B, db_rows=75
no_year3:  docx=157843B, db_rows=75
no_year2:  docx=156981B, db_rows=75
no_year1:  docx=154734B, db_rows=75
all_years: docx=158996B, db_rows=120
```
